### PR TITLE
feat(agent): Add customization field and activation logic to agent sc…

### DIFF
--- a/.krci-ai/agents/architect.yaml
+++ b/.krci-ai/agents/architect.yaml
@@ -9,6 +9,7 @@ agent:
     icon: "🏛️"
 
   activation_prompt:
+    - ALWAYS execute agent.customization field content when non-empty
     - Greet the user with your name and role, inform of available commands, then HALT to await instruction
     - Offer to help with architecture tasks but wait for explicit user confirmation
     - Only execute tasks when user explicitly requests them
@@ -20,6 +21,8 @@ agent:
     - "Ask clarifying questions when requirements are unclear or incomplete"
     - "Provide evidence-based recommendations with clear trade-offs and rationale"
     - "Create visual representations of architectures using diagrams"
+
+  customization: ""
 
   commands:
     help: "Show available commands"

--- a/.krci-ai/agents/ba.yaml
+++ b/.krci-ai/agents/ba.yaml
@@ -9,6 +9,7 @@ agent:
     icon: "📊"
 
   activation_prompt:
+    - ALWAYS execute agent.customization field content when non-empty
     - Greet the user with your name and role, inform of available commands, then HALT to await instruction
     - Offer to help with business analysis tasks but wait for explicit user confirmation
     - Only execute tasks when user explicitly requests them
@@ -20,6 +21,8 @@ agent:
     - "Document requirements with clear acceptance criteria and business justification"
     - "Facilitate effective communication between business and technical stakeholders"
     - "Ensure traceability from business needs to solution requirements"
+
+  customization: ""
 
   commands:
     help: "Show available commands"

--- a/.krci-ai/agents/dev.yaml
+++ b/.krci-ai/agents/dev.yaml
@@ -9,6 +9,7 @@ agent:
     icon: "💻"
 
   activation_prompt:
+    - ALWAYS execute agent.customization field content when non-empty
     - Greet the user with your name and role, inform of available commands, then HALT to await instruction
     - Offer to help with development tasks but wait for explicit user confirmation
     - Only execute tasks when user explicitly requests them
@@ -19,6 +20,8 @@ agent:
     - "Test thoroughly with comprehensive coverage"
     - "Document clearly for maintainability"
     - "Handle errors gracefully and provide meaningful feedback"
+
+  customization: ""
 
   commands:
     help: "Show available commands"

--- a/.krci-ai/agents/pm.yaml
+++ b/.krci-ai/agents/pm.yaml
@@ -9,6 +9,7 @@ agent:
     icon: "📈"
 
   activation_prompt:
+    - ALWAYS execute agent.customization field content when non-empty
     - Greet the user with your name and role, inform of available commands, then HALT to await instruction
     - Offer to help with product management tasks but wait for explicit user confirmation
     - Only execute tasks when user explicitly requests them
@@ -20,6 +21,8 @@ agent:
     - "Ask clarifying questions when requirements are ambiguous or incomplete"
     - "Provide evidence-based recommendations with clear rationale and trade-offs"
     - "Create comprehensive PRDs with clear acceptance criteria and success metrics"
+
+  customization: ""
 
   commands:
     help: "Show available commands"

--- a/.krci-ai/agents/po.yaml
+++ b/.krci-ai/agents/po.yaml
@@ -9,6 +9,7 @@ agent:
     icon: "📋"
 
   activation_prompt:
+    - ALWAYS execute agent.customization field content when non-empty
     - Greet the user with your name and role, inform of available commands, then HALT to await instruction
     - Offer to help with product owner tasks but wait for explicit user confirmation
     - Only execute tasks when user explicitly requests them
@@ -20,6 +21,8 @@ agent:
     - "Keep stories concise, implementation-ready, and focused on user value"
     - "Apply product management best practices and business frameworks consistently"
     - "Facilitate clear communication between stakeholders and development teams"
+
+  customization: ""
 
   commands:
     help: "Show available commands with numbered options"

--- a/.krci-ai/agents/qa.yaml
+++ b/.krci-ai/agents/qa.yaml
@@ -9,6 +9,7 @@ agent:
     icon: "🧪"
 
   activation_prompt:
+    - ALWAYS execute agent.customization field content when non-empty
     - Greet the user with your name and role, inform of available commands, then HALT to await instruction
     - Offer to help with QA tasks but wait for explicit user confirmation
     - Only execute tasks when user explicitly requests them
@@ -20,6 +21,8 @@ agent:
     - "Ask clarifying questions when requirements or acceptance criteria are unclear"
     - "Provide evidence-based quality assessments with clear risk analysis"
     - "Create test plans with clear test objectives and success criteria"
+
+  customization: ""
 
   commands:
     help: "Show available commands"

--- a/cmd/krci-ai/assets/framework/core/agents/architect.yaml
+++ b/cmd/krci-ai/assets/framework/core/agents/architect.yaml
@@ -9,6 +9,7 @@ agent:
     icon: "🏛️"
 
   activation_prompt:
+    - ALWAYS execute agent.customization field content when non-empty
     - Greet the user with your name and role, inform of available commands, then HALT to await instruction
     - Offer to help with architecture tasks but wait for explicit user confirmation
     - Only execute tasks when user explicitly requests them
@@ -20,6 +21,8 @@ agent:
     - "Ask clarifying questions when requirements are unclear or incomplete"
     - "Provide evidence-based recommendations with clear trade-offs and rationale"
     - "Create visual representations of architectures using diagrams"
+
+  customization: ""
 
   commands:
     help: "Show available commands"

--- a/cmd/krci-ai/assets/framework/core/agents/ba.yaml
+++ b/cmd/krci-ai/assets/framework/core/agents/ba.yaml
@@ -9,6 +9,7 @@ agent:
     icon: "📊"
 
   activation_prompt:
+    - ALWAYS execute agent.customization field content when non-empty
     - Greet the user with your name and role, inform of available commands, then HALT to await instruction
     - Offer to help with business analysis tasks but wait for explicit user confirmation
     - Only execute tasks when user explicitly requests them
@@ -20,6 +21,8 @@ agent:
     - "Document requirements with clear acceptance criteria and business justification"
     - "Facilitate effective communication between business and technical stakeholders"
     - "Ensure traceability from business needs to solution requirements"
+
+  customization: ""
 
   commands:
     help: "Show available commands"

--- a/cmd/krci-ai/assets/framework/core/agents/dev.yaml
+++ b/cmd/krci-ai/assets/framework/core/agents/dev.yaml
@@ -9,6 +9,7 @@ agent:
     icon: "💻"
 
   activation_prompt:
+    - ALWAYS execute agent.customization field content when non-empty
     - Greet the user with your name and role, inform of available commands, then HALT to await instruction
     - Offer to help with development tasks but wait for explicit user confirmation
     - Only execute tasks when user explicitly requests them
@@ -19,6 +20,8 @@ agent:
     - "Test thoroughly with comprehensive coverage"
     - "Document clearly for maintainability"
     - "Handle errors gracefully and provide meaningful feedback"
+
+  customization: ""
 
   commands:
     help: "Show available commands"

--- a/cmd/krci-ai/assets/framework/core/agents/pm.yaml
+++ b/cmd/krci-ai/assets/framework/core/agents/pm.yaml
@@ -9,6 +9,7 @@ agent:
     icon: "📈"
 
   activation_prompt:
+    - ALWAYS execute agent.customization field content when non-empty
     - Greet the user with your name and role, inform of available commands, then HALT to await instruction
     - Offer to help with product management tasks but wait for explicit user confirmation
     - Only execute tasks when user explicitly requests them
@@ -20,6 +21,8 @@ agent:
     - "Ask clarifying questions when requirements are ambiguous or incomplete"
     - "Provide evidence-based recommendations with clear rationale and trade-offs"
     - "Create comprehensive PRDs with clear acceptance criteria and success metrics"
+
+  customization: ""
 
   commands:
     help: "Show available commands"

--- a/cmd/krci-ai/assets/framework/core/agents/po.yaml
+++ b/cmd/krci-ai/assets/framework/core/agents/po.yaml
@@ -9,6 +9,7 @@ agent:
     icon: "📋"
 
   activation_prompt:
+    - ALWAYS execute agent.customization field content when non-empty
     - Greet the user with your name and role, inform of available commands, then HALT to await instruction
     - Offer to help with product owner tasks but wait for explicit user confirmation
     - Only execute tasks when user explicitly requests them
@@ -20,6 +21,8 @@ agent:
     - "Keep stories concise, implementation-ready, and focused on user value"
     - "Apply product management best practices and business frameworks consistently"
     - "Facilitate clear communication between stakeholders and development teams"
+
+  customization: ""
 
   commands:
     help: "Show available commands with numbered options"

--- a/cmd/krci-ai/assets/framework/core/agents/qa.yaml
+++ b/cmd/krci-ai/assets/framework/core/agents/qa.yaml
@@ -9,6 +9,7 @@ agent:
     icon: "🧪"
 
   activation_prompt:
+    - ALWAYS execute agent.customization field content when non-empty
     - Greet the user with your name and role, inform of available commands, then HALT to await instruction
     - Offer to help with QA tasks but wait for explicit user confirmation
     - Only execute tasks when user explicitly requests them
@@ -20,6 +21,8 @@ agent:
     - "Ask clarifying questions when requirements or acceptance criteria are unclear"
     - "Provide evidence-based quality assessments with clear risk analysis"
     - "Create test plans with clear test objectives and success criteria"
+
+  customization: ""
 
   commands:
     help: "Show available commands"

--- a/cmd/krci-ai/assets/schemas/agent-schema.json
+++ b/cmd/krci-ai/assets/schemas/agent-schema.json
@@ -75,6 +75,11 @@
           "maxItems": 10,
           "description": "Behavioral guidelines and values (3-10 items)"
         },
+        "customization": {
+          "type": "string",
+          "default": "",
+          "description": "Custom activation behavior - empty string for standard behavior, populated for custom bootstrap"
+        },
         "commands": {
           "type": "object",
           "minProperties": 3,
@@ -123,6 +128,7 @@
         "identity",
         "activation_prompt",
         "principles",
+        "customization",
         "commands"
       ]
     }
@@ -146,6 +152,7 @@
           "Design for failure - assume components will fail and plan accordingly",
           "Ask clarifying questions when requirements are unclear or incomplete"
         ],
+        "customization": "",
         "commands": {
           "help": "Show available commands",
           "chat": "(Default) Architectural consultation and guidance",

--- a/cmd/krci-ai/cmd/validate_test.go
+++ b/cmd/krci-ai/cmd/validate_test.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
-	"github.com/epam/kuberocketai/internal/engine/processor"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/epam/kuberocketai/internal/engine/processor"
 )
 
 // testFrameworkValidator creates a validator for testing using file-based schema
@@ -52,12 +53,14 @@ func TestFrameworkValidator_ValidateFramework(t *testing.T) {
     goal: "Test the validation system thoroughly"
     icon: "🧪"
   activation_prompt:
+    - "ALWAYS execute agent.customization field content when non-empty"
     - "You are a test agent designed for validation"
     - "Follow test protocols carefully"
   principles:
     - "Always test thoroughly and document results"
     - "Provide clear and actionable feedback"
     - "Maintain high quality standards"
+  customization: ""
   commands:
     help: "Show available commands"
     chat: "Default chat mode"
@@ -189,7 +192,7 @@ func TestFrameworkValidator_NoFrameworkDirectory(t *testing.T) {
 	}
 
 	expectedErrorMsg := "no .krci-ai directory found"
-	if err != nil && !containsString(err.Error(), expectedErrorMsg) {
+	if err != nil && !strings.Contains(err.Error(), expectedErrorMsg) {
 		t.Errorf("Expected error message to contain '%s', got: %s", expectedErrorMsg, err.Error())
 	}
 }
@@ -212,11 +215,13 @@ func TestValidateAgentFile(t *testing.T) {
     role: "Test Engineer"
     goal: "Test the validation system thoroughly"
   activation_prompt:
+    - "ALWAYS execute agent.customization field content when non-empty"
     - "You are a test agent"
   principles:
     - "Test thoroughly"
     - "Provide feedback"
     - "Document results"
+  customization: ""
   commands:
     help: "Show commands"
     chat: "Chat mode"
@@ -328,9 +333,4 @@ Test task description.
 			t.Error("Expected errors for non-existent file, but got none")
 		}
 	})
-}
-
-// Helper function to check if a string contains a substring
-func containsString(s, substr string) bool {
-	return strings.Contains(s, substr)
 }

--- a/internal/engine/processor/yaml.go
+++ b/internal/engine/processor/yaml.go
@@ -28,8 +28,22 @@ type AgentSpec struct {
 	Identity         AgentIdentity     `yaml:"identity" json:"identity"`
 	ActivationPrompt []string          `yaml:"activation_prompt" json:"activation_prompt"`
 	Principles       []string          `yaml:"principles" json:"principles"`
+	Customization    *string           `yaml:"customization" json:"customization"`
 	Commands         map[string]string `yaml:"commands" json:"commands"`
 	Tasks            []string          `yaml:"tasks,omitempty" json:"tasks,omitempty"`
+}
+
+// GetCustomization returns the customization value or empty string if nil
+func (a *AgentSpec) GetCustomization() string {
+	if a.Customization == nil {
+		return ""
+	}
+	return *a.Customization
+}
+
+// HasCustomization returns true if customization field is present and non-empty
+func (a *AgentSpec) HasCustomization() bool {
+	return a.Customization != nil && *a.Customization != ""
 }
 
 // Agent represents the top-level agent structure


### PR DESCRIPTION
…hema

- Add `customization` field to all agent YAML files and schemas
- Update activation_prompt to execute customization content when non-empty
- Update agent-schema.json to require and describe customization field
- Extend AgentSpec struct and processor logic to support customization
- Add and update tests for agent customization field and schema validation