### PR TITLE
fix(validate): enforce additionalProperties:false in agent schema val…

### DIFF
--- a/cmd/krci-ai/assets/schemas/agent-schema.json
+++ b/cmd/krci-ai/assets/schemas/agent-schema.json
@@ -130,7 +130,8 @@
         "principles",
         "customization",
         "commands"
-      ]
+      ],
+      "additionalProperties": false
     }
   },
   "required": ["agent"],


### PR DESCRIPTION
…idation

The agent schema validation was not properly rejecting unknown fields like 'templates' and 'data' due to Go struct unmarshaling silently dropping them. This allowed invalid agent configurations to pass validation.

Changes:
- Add additionalProperties:false to agent object in schema
- Add raw YAML parsing to capture all fields before validation
- Add ValidateAgentRaw function to validate complete field set
- Unknown fields now properly cause validation failures