### PR TITLE
fix(installer): correct task file validation to check for .md files

### DIFF
--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -38,7 +38,5 @@ agent:
     exit: "Exit Architect persona and return to normal mode"
 
   tasks:
-    - ./.krci-ai/tasks/analyze-requirements.md
-    - ./.krci-ai/tasks/create-system-design.md
-    - ./.krci-ai/tasks/review-architecture.md
+    - ./.krci-ai/tasks/create-sad.md
 ```

--- a/.claude/commands/pm.md
+++ b/.claude/commands/pm.md
@@ -33,16 +33,10 @@ agent:
     help: "Show available commands"
     chat: "(Default) Product management consultation and guidance"
     create-epic: "Execute task create-epic"
-    create: "Create comprehensive product requirements document"
-    analyze: "Analyze market conditions and competitive landscape"
-    prioritize: "Prioritize features based on impact and effort"
-    communicate: "Create stakeholder reports and communications"
+    create-prd: "Create comprehensive product requirements document"
     exit: "Exit Product Manager persona and return to normal mode"
 
   tasks:
     - ./.krci-ai/tasks/create-epic.md
     - ./.krci-ai/tasks/create-prd.md
-    - ./.krci-ai/tasks/analyze-market.md
-    - ./.krci-ai/tasks/prioritize-features.md
-    - ./.krci-ai/tasks/stakeholder-communication.md
 ```

--- a/.cursor/rules/architect.mdc
+++ b/.cursor/rules/architect.mdc
@@ -44,7 +44,5 @@ agent:
     exit: "Exit Architect persona and return to normal mode"
 
   tasks:
-    - ./.krci-ai/tasks/analyze-requirements.md
-    - ./.krci-ai/tasks/create-system-design.md
-    - ./.krci-ai/tasks/review-architecture.md
+    - ./.krci-ai/tasks/create-sad.md
 ```

--- a/.cursor/rules/pm.mdc
+++ b/.cursor/rules/pm.mdc
@@ -39,16 +39,10 @@ agent:
     help: "Show available commands"
     chat: "(Default) Product management consultation and guidance"
     create-epic: "Execute task create-epic"
-    create: "Create comprehensive product requirements document"
-    analyze: "Analyze market conditions and competitive landscape"
-    prioritize: "Prioritize features based on impact and effort"
-    communicate: "Create stakeholder reports and communications"
+    create-prd: "Create comprehensive product requirements document"
     exit: "Exit Product Manager persona and return to normal mode"
 
   tasks:
     - ./.krci-ai/tasks/create-epic.md
     - ./.krci-ai/tasks/create-prd.md
-    - ./.krci-ai/tasks/analyze-market.md
-    - ./.krci-ai/tasks/prioritize-features.md
-    - ./.krci-ai/tasks/stakeholder-communication.md
 ```

--- a/internal/assets/installer.go
+++ b/internal/assets/installer.go
@@ -279,7 +279,7 @@ func (i *Installer) ValidateInstallation() error {
 
 	// Check that tasks directory has files
 	tasksPath := i.GetTasksPath()
-	taskFiles, err := filepath.Glob(filepath.Join(tasksPath, "*.yaml"))
+	taskFiles, err := filepath.Glob(filepath.Join(tasksPath, "*.md"))
 	if err != nil {
 		return fmt.Errorf("failed to check task files: %w", err)
 	}


### PR DESCRIPTION
The ValidateInstallation method was incorrectly looking for *.yaml files in the tasks directory, but tasks are now stored as *.md files. This caused installation validation to fail even when files were properly installed.