### PR TITLE
feat(install): add VS Code chat mode integration with enhanced tool s…

### DIFF
--- a/cmd/krci-ai/cmd/install.go
+++ b/cmd/krci-ai/cmd/install.go
@@ -28,6 +28,7 @@ const (
 	ideAll    = "all"
 	ideCursor = "cursor"
 	ideClaude = "claude"
+	ideVSCode = "vscode"
 )
 
 // installCmd represents the install command
@@ -84,7 +85,7 @@ Examples:
 
 		// Validate IDE flag value if provided
 		if ideFlag != "" {
-			validIDEs := []string{ideCursor, ideClaude, "vscode", "windsurf", ideAll}
+			validIDEs := []string{ideCursor, ideClaude, ideVSCode, "windsurf", ideAll}
 			isValid := false
 			for _, valid := range validIDEs {
 				if ideFlag == valid {
@@ -149,6 +150,15 @@ Examples:
 			output.PrintSuccess("Claude Code integration installed successfully!")
 		}
 
+		if ideFlag == ideVSCode || ideFlag == ideAll {
+			output.PrintInfo("Setting up VS Code integration...")
+			if err := installer.InstallVSCodeIntegration(); err != nil {
+				errorHandler.HandleError(err, "Failed to install VS Code integration")
+				return
+			}
+			output.PrintSuccess("VS Code integration installed successfully!")
+		}
+
 		// Success
 		output.PrintSuccess("Framework installation completed successfully!")
 		output.PrintInfo("Framework components installed to: " + installer.GetInstallationPath())
@@ -163,6 +173,9 @@ Examples:
 		}
 		if ideFlag == ideClaude || ideFlag == ideAll {
 			output.PrintInfo("  • Claude Code commands installed to: .claude/commands/")
+		}
+		if ideFlag == ideVSCode || ideFlag == ideAll {
+			output.PrintInfo("  • VS Code chat modes installed to: .vscode/chatmodes/")
 		}
 	},
 }

--- a/cmd/krci-ai/cmd/install_test.go
+++ b/cmd/krci-ai/cmd/install_test.go
@@ -59,3 +59,26 @@ func TestInstallCommandHasRequiredFlags(t *testing.T) {
 		}
 	}
 }
+
+// TestIDEValidation verifies that IDE validation includes VS Code
+func TestIDEValidation(t *testing.T) {
+	validIDEs := []string{ideCursor, ideClaude, ideVSCode, "windsurf", ideAll}
+
+	// Test that vscode is in valid IDEs
+	found := false
+	for _, ide := range validIDEs {
+		if ide == ideVSCode {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Error("VS Code (vscode) should be in the list of valid IDEs")
+	}
+
+	// Test that the ideVSCode constant is correctly defined
+	if ideVSCode != "vscode" {
+		t.Errorf("Expected ideVSCode constant to be 'vscode', got '%s'", ideVSCode)
+	}
+}

--- a/internal/assets/installer.go
+++ b/internal/assets/installer.go
@@ -36,6 +36,7 @@ const (
 	embeddedPrefix    = "assets/framework/core"
 	cursorRulesDir    = ".cursor/rules"
 	claudeCommandsDir = ".claude/commands"
+	vscodeModesDir    = ".vscode/chatmodes"
 )
 
 // AgentData represents the parsed YAML structure for agent files
@@ -107,6 +108,36 @@ CRITICAL: Carefully read the YAML agent definition below. Immediately activate t
 
 `+"```yaml\n%s```\n",
 		agentName,
+		role,
+		string(yamlContent))
+}
+
+// VSCodeIntegration implements IDEIntegration for VS Code
+type VSCodeIntegration struct {
+	targetDir string
+}
+
+func (v *VSCodeIntegration) GetDirectoryPath() string {
+	return filepath.Join(v.targetDir, vscodeModesDir)
+}
+
+func (v *VSCodeIntegration) GetFileExtension() string {
+	return ".chatmode.md"
+}
+
+func (v *VSCodeIntegration) GenerateContent(agentName, role string, yamlContent []byte) string {
+	return fmt.Sprintf(`---
+description: Activate %s role for specialized development assistance
+tools: ['codebase', 'search', 'usages', 'findTestFiles', 'problems', 'changes', 'fetch']
+---
+
+# %s Agent Chat Mode
+
+CRITICAL: Carefully read the YAML agent definition below. Immediately activate the %s persona by following the activation instructions, and remain in this persona until you receive an explicit command to exit.
+
+`+"```yaml\n%s```\n",
+		role,
+		role,
 		role,
 		string(yamlContent))
 }
@@ -376,4 +407,10 @@ func (i *Installer) InstallCursorIntegration() error {
 func (i *Installer) InstallClaudeIntegration() error {
 	integration := &ClaudeIntegration{targetDir: i.targetDir}
 	return i.installIDEIntegration(integration, "Claude Code")
+}
+
+// InstallVSCodeIntegration creates .vscode/chatmodes directory and generates .chatmode.md files for agents
+func (i *Installer) InstallVSCodeIntegration() error {
+	integration := &VSCodeIntegration{targetDir: i.targetDir}
+	return i.installIDEIntegration(integration, "VS Code")
 }

--- a/internal/assets/installer_test.go
+++ b/internal/assets/installer_test.go
@@ -176,6 +176,45 @@ func TestClaudeIntegration(t *testing.T) {
 	}
 }
 
+func TestVSCodeIntegration(t *testing.T) {
+	tempDir := t.TempDir()
+	integration := &VSCodeIntegration{targetDir: tempDir}
+
+	expectedPath := filepath.Join(tempDir, vscodeModesDir)
+	if integration.GetDirectoryPath() != expectedPath {
+		t.Errorf("Expected directory path '%s', got '%s'", expectedPath, integration.GetDirectoryPath())
+	}
+
+	if integration.GetFileExtension() != ".chatmode.md" {
+		t.Errorf("Expected file extension '.chatmode.md', got '%s'", integration.GetFileExtension())
+	}
+
+	content := integration.GenerateContent("test", "Test Role", []byte("test: yaml"))
+	if content == "" {
+		t.Error("GenerateContent returned empty string")
+	}
+
+	// Check if content contains expected parts
+	if !contains(content, "---") {
+		t.Error("Content missing front matter delimiters")
+	}
+	if !contains(content, "description: Activate Test Role role for specialized development assistance") {
+		t.Error("Content missing description in front matter")
+	}
+	if !contains(content, "tools: ['codebase', 'search', 'usages', 'findTestFiles', 'problems', 'changes', 'fetch']") {
+		t.Error("Content missing tools in front matter")
+	}
+	if !contains(content, "# Test Role Agent Chat Mode") {
+		t.Error("Content missing agent chat mode header")
+	}
+	if !contains(content, "Test Role") {
+		t.Error("Content missing role")
+	}
+	if !contains(content, "test: yaml") {
+		t.Error("Content missing YAML content")
+	}
+}
+
 func TestValidateInstallationWithoutInstallation(t *testing.T) {
 	tempDir := t.TempDir()
 	installer := NewInstaller(tempDir, testAssets)


### PR DESCRIPTION
…upport

- Add VS Code integration alongside existing Cursor and Claude IDE support
- Implement VSCodeIntegration struct following established IDE integration pattern
- Generate .chatmode.md files in .vscode/chatmodes/ directory with proper front matter
- Include comprehensive tool configuration: codebase, search, usages, findTestFiles, problems, changes, fetch
- Add InstallVSCodeIntegration method and update install command to support --ide=vscode
- Maintain backward compatibility with existing --ide=all flag behavior
- Add comprehensive unit tests covering VS Code integration functionality
- Update command validation to include VS Code as valid IDE option