### PR TITLE
refactor: align VSCode chatmodes with official docs and eliminate har…

### DIFF
--- a/cmd/krci-ai/cmd/install.go
+++ b/cmd/krci-ai/cmd/install.go
@@ -169,13 +169,13 @@ Examples:
 		output.PrintInfo("  • Run 'krci-ai validate' to verify installation")
 
 		if ideFlag == ideCursor || ideFlag == ideAll {
-			output.PrintInfo("  • Cursor IDE rules installed to: .cursor/rules/")
+			output.PrintInfo("  • Cursor IDE rules installed to: " + installer.GetCursorRulesPath() + "/")
 		}
 		if ideFlag == ideClaude || ideFlag == ideAll {
-			output.PrintInfo("  • Claude Code commands installed to: .claude/commands/")
+			output.PrintInfo("  • Claude Code commands installed to: " + installer.GetClaudeCommandsPath() + "/")
 		}
 		if ideFlag == ideVSCode || ideFlag == ideAll {
-			output.PrintInfo("  • VS Code chat modes installed to: .vscode/chatmodes/")
+			output.PrintInfo("  • VS Code chat modes installed to: " + installer.GetVSCodeChatmodesPath() + "/")
 		}
 	},
 }

--- a/internal/assets/installer.go
+++ b/internal/assets/installer.go
@@ -36,7 +36,7 @@ const (
 	embeddedPrefix    = "assets/framework/core"
 	cursorRulesDir    = ".cursor/rules"
 	claudeCommandsDir = ".claude/commands"
-	vscodeModesDir    = ".vscode/chatmodes"
+	vscodeModesDir    = ".github/chatmodes"
 )
 
 // AgentData represents the parsed YAML structure for agent files
@@ -292,6 +292,21 @@ func (i *Installer) GetDataPath() string {
 	return filepath.Join(i.targetDir, krciAIDir, dataDir)
 }
 
+// GetCursorRulesPath returns the path to the Cursor rules directory
+func (i *Installer) GetCursorRulesPath() string {
+	return filepath.Join(i.targetDir, cursorRulesDir)
+}
+
+// GetClaudeCommandsPath returns the path to the Claude commands directory
+func (i *Installer) GetClaudeCommandsPath() string {
+	return filepath.Join(i.targetDir, claudeCommandsDir)
+}
+
+// GetVSCodeChatmodesPath returns the path to the VS Code chatmodes directory
+func (i *Installer) GetVSCodeChatmodesPath() string {
+	return filepath.Join(i.targetDir, vscodeModesDir)
+}
+
 // ValidateInstallation performs basic validation of the installation
 func (i *Installer) ValidateInstallation() error {
 	if !i.IsInstalled() {
@@ -409,7 +424,7 @@ func (i *Installer) InstallClaudeIntegration() error {
 	return i.installIDEIntegration(integration, "Claude Code")
 }
 
-// InstallVSCodeIntegration creates .vscode/chatmodes directory and generates .chatmode.md files for agents
+// InstallVSCodeIntegration creates .github/chatmodes directory and generates .chatmode.md files for agents
 func (i *Installer) InstallVSCodeIntegration() error {
 	integration := &VSCodeIntegration{targetDir: i.targetDir}
 	return i.installIDEIntegration(integration, "VS Code")


### PR DESCRIPTION
…dcoded paths

- Move VSCode chatmodes from .vscode/chatmodes to .github/chatmodes per VSCode official documentation
- Add getter methods to Installer for IDE integration paths (GetCursorRulesPath, GetClaudeCommandsPath, GetVSCodeChatmodesPath)
- Replace hardcoded path strings in install output messages with dynamic path methods
- Update comment to reflect new VSCode chatmodes directory location

This ensures single source of truth for paths and aligns with VSCode chat mode specifications.