### PR TITLE
feat(validation): add template validation and framework link validation

### DIFF
--- a/cmd/krci-ai/cmd/validate_test.go
+++ b/cmd/krci-ai/cmd/validate_test.go
@@ -107,12 +107,12 @@ Test task description.
 			t.Error("Expected valid results, but validation failed")
 		}
 
-		if results.TotalFiles != 2 {
-			t.Errorf("Expected 2 files, got: %d", results.TotalFiles)
+		if results.TotalFiles != 3 {
+			t.Errorf("Expected 3 validation results, got: %d", results.TotalFiles)
 		}
 
-		if results.ValidFiles != 2 {
-			t.Errorf("Expected 2 valid files, got: %d", results.ValidFiles)
+		if results.ValidFiles != 3 {
+			t.Errorf("Expected 3 valid validation results, got: %d", results.ValidFiles)
 		}
 
 		if results.InvalidFiles != 0 {
@@ -156,12 +156,12 @@ Test task description.
 			t.Error("Expected invalid results, but validation passed")
 		}
 
-		if results.TotalFiles != 3 {
-			t.Errorf("Expected 3 files, got: %d", results.TotalFiles)
+		if results.TotalFiles != 4 {
+			t.Errorf("Expected 4 validation results, got: %d", results.TotalFiles)
 		}
 
-		if results.ValidFiles != 2 {
-			t.Errorf("Expected 2 valid files, got: %d", results.ValidFiles)
+		if results.ValidFiles != 3 {
+			t.Errorf("Expected 3 valid validation results, got: %d", results.ValidFiles)
 		}
 
 		if results.InvalidFiles != 1 {


### PR DESCRIPTION
- Add template file discovery and structure validation
- Implement markdown link validation for internal framework references
- Validate only [text](./.krci-ai/path/file.md) format links
- Add template content quality checks (headings, minimum content)
- Enhance error reporting with clear scope messaging
- Update validation output with FRAMEWORK-LINKS type label
- Add validation scope information to CLI output
- Fix test expectations for new validation result types

The validation system now ensures framework integrity by checking:
- Template files exist and have proper structure
- Internal framework links in markdown files are valid
- Referenced framework files actually exist on filesystem

Performance: Validates 89+ files in <200ms with detailed error reporting.