### PR TITLE
feat: implement complete bundle generation with CLI command

### DIFF
--- a/cmd/krci-ai/cmd/bundle.go
+++ b/cmd/krci-ai/cmd/bundle.go
@@ -1,0 +1,540 @@
+/*
+Copyright © 2025 KubeRocketAI Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/KubeRocketCI/kuberocketai/internal/assets"
+	"github.com/KubeRocketCI/kuberocketai/internal/cli"
+	"github.com/KubeRocketCI/kuberocketai/internal/validation"
+)
+
+// bundleCmd represents the bundle command
+var bundleCmd = &cobra.Command{
+	Use:   "bundle",
+	Short: "Generate complete agent bundles for web chat tools",
+	Long: `Generate complete agent bundles for web chat tools (ChatGPT, Gemini Pro, Claude Web).
+
+This command creates a single markdown file containing all KubeRocketAI framework 
+components optimized for web chat consumption. The bundle includes:
+- All 6 core SDLC agents (PM, Architect, Developer, QA, BA, PO) with complete definitions
+- All agent dependencies, tasks, and templates in consolidated format
+- Project-specific context from .krci-ai/data/ and .krci-ai/templates/ directories
+- System prompt structure with clear agent separation and role definitions
+
+Examples:
+  krci-ai bundle --all                           # Generate complete bundle at ./.krci-ai/bundle/all.md
+  krci-ai bundle --all --output my-framework.md  # Generate bundle with custom filename
+  krci-ai bundle --all --dry-run                 # Show bundle scope without generating files
+  krci-ai bundle --help                          # Show comprehensive usage information`,
+	RunE: runBundle,
+}
+
+// Bundle generation flags
+var (
+	bundleAll    bool
+	bundleDryRun bool
+	bundleOutput string
+)
+
+// BundleContent represents the aggregated content for bundle generation
+type BundleContent struct {
+	Agents    []AgentBundleInfo
+	Tasks     map[string]string
+	Templates map[string]string
+	DataFiles map[string]string
+}
+
+// AgentBundleInfo represents agent information with content for bundling
+type AgentBundleInfo struct {
+	FilePath string
+	Content  string
+	Name     string
+	Role     string
+}
+
+func init() {
+	rootCmd.AddCommand(bundleCmd)
+
+	// Add flags
+	bundleCmd.Flags().BoolVar(&bundleAll, "all", false, "Generate complete bundle with all agents and dependencies")
+	bundleCmd.Flags().BoolVar(&bundleDryRun, "dry-run", false, "Show bundle scope without generating files")
+	bundleCmd.Flags().StringVar(&bundleOutput, "output", "", "Custom output filename (creates ./.krci-ai/bundle/filename)")
+}
+
+// runBundle executes the bundle command
+func runBundle(cmd *cobra.Command, args []string) error {
+	// Create output and error handlers
+	output := cli.NewOutputHandler()
+	errorHandler := cli.NewErrorHandler()
+
+	// Validate flags
+	if !bundleAll {
+		output.PrintError("Bundle generation requires --all flag")
+		output.PrintInfo("Usage: krci-ai bundle --all")
+		return fmt.Errorf("--all flag is required")
+	}
+
+	// Get current working directory
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current working directory: %w", err)
+	}
+
+	// Check if framework is installed
+	frameworkDir := filepath.Join(currentDir, ".krci-ai")
+	if _, statErr := os.Stat(frameworkDir); os.IsNotExist(statErr) {
+		output.PrintError("No .krci-ai directory found in current directory")
+		output.PrintInfo("Run 'krci-ai install' to set up the framework first")
+		return fmt.Errorf("framework not installed")
+	}
+
+	output.PrintProgress("Validating framework integrity...")
+
+	// Run framework validation before bundle generation
+	if validationErr := runFrameworkValidation(currentDir); validationErr != nil {
+		errorHandler.HandleError(validationErr, "Framework validation failed")
+		output.PrintError("Bundle generation requires a valid framework")
+		output.PrintInfo("Fix validation errors and try again")
+		return validationErr
+	}
+
+	output.PrintSuccess("Framework validation passed")
+
+	// Collect bundle content
+	output.PrintProgress("Discovering agents and dependencies...")
+
+	bundleContent, err := collectBundleContent(currentDir)
+	if err != nil {
+		errorHandler.HandleError(err, "Failed to collect bundle content")
+		return err
+	}
+
+	// Show dry-run information if requested
+	if bundleDryRun {
+		return showBundleScope(output, bundleContent)
+	}
+
+	// Generate bundle filename
+	bundleFilename := generateBundleFilename(bundleOutput)
+	bundleDir := filepath.Join(currentDir, ".krci-ai", "bundle")
+	bundlePath := filepath.Join(bundleDir, bundleFilename)
+
+	output.PrintInfo(fmt.Sprintf("Generating bundle: %s", bundlePath))
+
+	// Create bundle directory
+	if err := os.MkdirAll(bundleDir, 0755); err != nil {
+		return fmt.Errorf("failed to create bundle directory: %w", err)
+	}
+
+	// Generate and write bundle
+	bundleMarkdown := generateBundleMarkdown(bundleContent)
+
+	if err := writeBundleFile(bundlePath, bundleMarkdown); err != nil {
+		errorHandler.HandleError(err, "Failed to write bundle file")
+		return err
+	}
+
+	// Success
+	output.PrintSuccess("Bundle generated successfully!")
+	output.PrintInfo(fmt.Sprintf("Bundle file: %s", bundlePath))
+	output.PrintInfo(fmt.Sprintf("Bundle size: %d bytes", len(bundleMarkdown)))
+
+	// Show usage instructions
+	output.PrintInfo("\nUsage instructions:")
+	output.PrintInfo("• Copy the entire bundle content to your web chat tool (ChatGPT, Claude Web, Gemini Pro)")
+	output.PrintInfo("• The bundle includes all agents, tasks, templates, and project-specific data")
+	output.PrintInfo("• Each section is clearly separated with collision-resistant delimiters")
+
+	return nil
+}
+
+// runFrameworkValidation runs the existing validation logic
+func runFrameworkValidation(currentDir string) error {
+	// Initialize enhanced validation system (reuse existing validation)
+	analyzer := validation.NewFrameworkAnalyzer(currentDir)
+
+	// Run optimized framework analysis with caching
+	issues, _, err := analyzer.OptimizedAnalyzeFramework()
+	if err != nil {
+		return fmt.Errorf("framework analysis failed: %w", err)
+	}
+
+	// Check for critical issues that would prevent bundle generation
+	for _, issue := range issues {
+		if issue.Severity == validation.SeverityCritical {
+			return fmt.Errorf("critical validation error: %s", issue.Message)
+		}
+	}
+
+	return nil
+}
+
+// collectBundleContent discovers and collects all framework content
+func collectBundleContent(currentDir string) (*BundleContent, error) {
+	// Create discovery service
+	discovery := assets.NewDiscovery(currentDir, GetEmbeddedAssets())
+
+	// Discover agents with dependencies
+	agentDeps, err := discovery.DiscoverAgentsWithDependencies()
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover agents: %w", err)
+	}
+
+	content := &BundleContent{
+		Agents:    make([]AgentBundleInfo, 0),
+		Tasks:     make(map[string]string),
+		Templates: make(map[string]string),
+		DataFiles: make(map[string]string),
+	}
+
+	// Collect agent files
+	for _, agent := range agentDeps {
+		agentContent, err := os.ReadFile(agent.FilePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read agent file %s: %w", agent.FilePath, err)
+		}
+
+		relPath, _ := filepath.Rel(currentDir, agent.FilePath)
+		content.Agents = append(content.Agents, AgentBundleInfo{
+			FilePath: relPath,
+			Content:  string(agentContent),
+			Name:     agent.Name,
+			Role:     agent.Role,
+		})
+
+		// Collect task files
+		for _, taskPath := range agent.Tasks {
+			fullTaskPath := filepath.Join(currentDir, ".krci-ai", "tasks", taskPath)
+			if taskContent, err := os.ReadFile(fullTaskPath); err == nil {
+				relTaskPath := filepath.Join("tasks", taskPath)
+				content.Tasks[relTaskPath] = string(taskContent)
+			}
+		}
+
+		// Collect template files
+		for _, templatePath := range agent.Templates {
+			fullTemplatePath := filepath.Join(currentDir, ".krci-ai", "templates", templatePath)
+			if templateContent, err := os.ReadFile(fullTemplatePath); err == nil {
+				relTemplatePath := filepath.Join("templates", templatePath)
+				content.Templates[relTemplatePath] = string(templateContent)
+			}
+		}
+
+		// Collect data files
+		for _, dataPath := range agent.DataFiles {
+			fullDataPath := filepath.Join(currentDir, ".krci-ai", "data", dataPath)
+			if dataContent, err := os.ReadFile(fullDataPath); err == nil {
+				relDataPath := filepath.Join("data", dataPath)
+				content.DataFiles[relDataPath] = string(dataContent)
+			}
+		}
+	}
+
+	// Collect any additional templates and data files not referenced by agents
+	if err := collectAdditionalFiles(currentDir, content); err != nil {
+		return nil, fmt.Errorf("failed to collect additional files: %w", err)
+	}
+
+	return content, nil
+}
+
+// collectAdditionalFiles collects templates and data files not referenced by agents
+func collectAdditionalFiles(currentDir string, content *BundleContent) error {
+	// Collect additional templates
+	templatesDir := filepath.Join(currentDir, ".krci-ai", "templates")
+	if templateFiles, err := filepath.Glob(filepath.Join(templatesDir, "*.md")); err == nil {
+		for _, templateFile := range templateFiles {
+			relPath, _ := filepath.Rel(currentDir, templateFile)
+			relPath = strings.TrimPrefix(relPath, ".krci-ai/")
+
+			if _, exists := content.Templates[relPath]; !exists {
+				if templateContent, err := os.ReadFile(templateFile); err == nil {
+					content.Templates[relPath] = string(templateContent)
+				}
+			}
+		}
+	}
+
+	// Collect additional data files
+	dataDir := filepath.Join(currentDir, ".krci-ai", "data")
+	if err := filepath.Walk(dataDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // Skip files with errors
+		}
+
+		if !info.IsDir() && strings.HasSuffix(info.Name(), ".md") {
+			relPath, _ := filepath.Rel(currentDir, path)
+			relPath = strings.TrimPrefix(relPath, ".krci-ai/")
+
+			if _, exists := content.DataFiles[relPath]; !exists {
+				if dataContent, err := os.ReadFile(path); err == nil {
+					content.DataFiles[relPath] = string(dataContent)
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// showBundleScope displays bundle scope information for dry-run
+func showBundleScope(output *cli.OutputHandler, content *BundleContent) error {
+	output.PrintSuccess("Bundle Scope Analysis:")
+	output.PrintInfo(fmt.Sprintf("  Agents: %d", len(content.Agents)))
+	output.PrintInfo(fmt.Sprintf("  Tasks: %d", len(content.Tasks)))
+	output.PrintInfo(fmt.Sprintf("  Templates: %d", len(content.Templates)))
+	output.PrintInfo(fmt.Sprintf("  Data Files: %d", len(content.DataFiles)))
+
+	fmt.Println()
+	output.PrintInfo("Agent Files:")
+	for _, agent := range content.Agents {
+		fmt.Printf("  • %s (%s - %s)\n", agent.FilePath, agent.Name, agent.Role)
+	}
+
+	if len(content.Tasks) > 0 {
+		fmt.Println()
+		output.PrintInfo("Task Files:")
+		for taskPath := range content.Tasks {
+			fmt.Printf("  • %s\n", taskPath)
+		}
+	}
+
+	if len(content.Templates) > 0 {
+		fmt.Println()
+		output.PrintInfo("Template Files:")
+		for templatePath := range content.Templates {
+			fmt.Printf("  • %s\n", templatePath)
+		}
+	}
+
+	if len(content.DataFiles) > 0 {
+		fmt.Println()
+		output.PrintInfo("Data Files:")
+		for dataPath := range content.DataFiles {
+			fmt.Printf("  • %s\n", dataPath)
+		}
+	}
+
+	fmt.Println()
+	output.PrintInfo("Use 'krci-ai bundle --all' to generate the actual bundle file")
+
+	return nil
+}
+
+// generateBundleFilename creates the bundle filename
+func generateBundleFilename(customOutput string) string {
+	if customOutput != "" {
+		// Ensure .md extension
+		if !strings.HasSuffix(customOutput, ".md") {
+			customOutput += ".md"
+		}
+		return customOutput
+	}
+	return "all.md"
+}
+
+// generateBundleMarkdown creates the complete bundle markdown content
+func generateBundleMarkdown(content *BundleContent) string {
+	var result strings.Builder
+
+	// Add bundle header with usage instructions
+	addBundleHeader(&result)
+
+	// Add agents with their dependencies grouped together
+	for _, agent := range content.Agents {
+		addAgentSection(&result, agent, content)
+	}
+
+	// Add shared templates not associated with specific agents
+	addSharedTemplates(&result, content)
+
+	// Add shared data files
+	addSharedDataFiles(&result, content)
+
+	return result.String()
+}
+
+// addBundleHeader adds the comprehensive bundle header with usage instructions
+func addBundleHeader(result *strings.Builder) {
+	timestamp := time.Now().Format("2006-01-02 15:04:05 MST")
+
+	result.WriteString("# KubeRocketAI Framework Bundle\n\n")
+	result.WriteString("**Generated:** " + timestamp + "\n")
+	result.WriteString("**Purpose:** Complete framework bundle for web chat tools (ChatGPT, Claude Web, Gemini Pro)\n\n")
+
+	result.WriteString("## Usage Instructions\n\n")
+	result.WriteString("This bundle contains all KubeRocketAI framework components in a single file:\n")
+	result.WriteString("- **Agent Definitions:** 6 SDLC roles with complete specifications\n")
+	result.WriteString("- **Task Templates:** Workflow templates for common development tasks\n")
+	result.WriteString("- **Output Templates:** Consistent formatting templates\n")
+	result.WriteString("- **Reference Data:** Coding standards and best practices\n\n")
+
+	result.WriteString("### File Format Guide\n")
+	result.WriteString("- Each file section starts with `==== FILE: <path> ====`\n")
+	result.WriteString("- Original file content follows with preserved formatting\n")
+	result.WriteString("- Each file section ends with `==== END FILE ====`\n\n")
+
+	result.WriteString("### For LLM Understanding\n")
+	result.WriteString("When working with this bundle:\n")
+	result.WriteString("1. Each agent represents a specific SDLC role (PM, Architect, Developer, QA, BA, PO)\n")
+	result.WriteString("2. Tasks are workflow templates that agents can execute\n")
+	result.WriteString("3. Templates provide consistent output formatting\n")
+	result.WriteString("4. Data files contain project-specific standards and references\n\n")
+
+	result.WriteString("---\n\n")
+}
+
+// addAgentSection adds an agent section with its related tasks grouped together
+func addAgentSection(result *strings.Builder, agent AgentBundleInfo, content *BundleContent) {
+	// Add agent file
+	fmt.Fprintf(result, "==== FILE: %s ====\n", agent.FilePath)
+	result.WriteString(optimizeContent(agent.Content))
+	result.WriteString("\n==== END FILE ====\n\n")
+
+	// Add agent-specific tasks immediately after the agent definition
+	// This improves LLM context by keeping related content together
+	agentTasks := getAgentTasks(agent.FilePath, content)
+	for _, taskPath := range agentTasks {
+		if taskContent, exists := content.Tasks[taskPath]; exists {
+			fmt.Fprintf(result, "==== FILE: %s ====\n", taskPath)
+			result.WriteString(optimizeContent(taskContent))
+			result.WriteString("\n==== END FILE ====\n\n")
+		}
+	}
+}
+
+// getAgentTasks extracts task references from agent YAML content
+func getAgentTasks(agentFilePath string, content *BundleContent) []string {
+	// Simple extraction - look for tasks in the agent content
+	var tasks []string
+
+	// Find the agent content
+	for _, agent := range content.Agents {
+		if agent.FilePath == agentFilePath {
+			// Parse tasks from YAML content (simple string matching)
+			lines := strings.Split(agent.Content, "\n")
+			inTasksSection := false
+
+			for _, line := range lines {
+				trimmed := strings.TrimSpace(line)
+				if strings.Contains(trimmed, "tasks:") {
+					inTasksSection = true
+					continue
+				}
+
+				if inTasksSection {
+					// Check if we've left the tasks section
+					if strings.HasPrefix(trimmed, "commands:") || strings.HasPrefix(trimmed, "principles:") {
+						break
+					}
+
+					// Extract task path
+					if taskRef, found := strings.CutPrefix(trimmed, "- "); found {
+						taskRef = strings.TrimSpace(taskRef)
+
+						// Convert to relative path format
+						if strings.HasPrefix(taskRef, "./.krci-ai/tasks/") {
+							taskPath := strings.TrimPrefix(taskRef, "./.krci-ai/")
+							tasks = append(tasks, taskPath)
+						}
+					}
+				}
+			}
+			break
+		}
+	}
+
+	return tasks
+}
+
+// addSharedTemplates adds template files not associated with specific agents
+func addSharedTemplates(result *strings.Builder, content *BundleContent) {
+	if len(content.Templates) > 0 {
+		result.WriteString("# Shared Templates\n\n")
+
+		for templatePath, templateContent := range content.Templates {
+			fmt.Fprintf(result, "==== FILE: %s ====\n", templatePath)
+			result.WriteString(optimizeContent(templateContent))
+			result.WriteString("\n==== END FILE ====\n\n")
+		}
+	}
+}
+
+// addSharedDataFiles adds data files
+func addSharedDataFiles(result *strings.Builder, content *BundleContent) {
+	if len(content.DataFiles) > 0 {
+		result.WriteString("# Reference Data\n\n")
+
+		for dataPath, dataContent := range content.DataFiles {
+			fmt.Fprintf(result, "==== FILE: %s ====\n", dataPath)
+			result.WriteString(optimizeContent(dataContent))
+			result.WriteString("\n==== END FILE ====\n\n")
+		}
+	}
+}
+
+// optimizeContent optimizes file content by removing excessive blank lines while preserving readability
+func optimizeContent(content string) string {
+	lines := strings.Split(content, "\n")
+	var optimizedLines []string
+	consecutiveEmptyLines := 0
+
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			consecutiveEmptyLines++
+			// Only allow up to 1 consecutive empty line
+			if consecutiveEmptyLines <= 1 {
+				optimizedLines = append(optimizedLines, line)
+			}
+		} else {
+			consecutiveEmptyLines = 0
+			optimizedLines = append(optimizedLines, line)
+		}
+	}
+
+	return strings.Join(optimizedLines, "\n")
+}
+
+// writeBundleFile writes the bundle content to file
+func writeBundleFile(bundlePath, content string) error {
+	file, err := os.Create(bundlePath)
+	if err != nil {
+		return fmt.Errorf("failed to create bundle file: %w", err)
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			// Log the error but don't override the main error
+			fmt.Fprintf(os.Stderr, "Warning: failed to close bundle file: %v\n", closeErr)
+		}
+	}()
+
+	if _, err := file.WriteString(content); err != nil {
+		return fmt.Errorf("failed to write bundle content: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/krci-ai/cmd/bundle_test.go
+++ b/cmd/krci-ai/cmd/bundle_test.go
@@ -1,0 +1,547 @@
+/*
+Copyright © 2025 KubeRocketAI Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBundleCommandExists(t *testing.T) {
+	if bundleCmd == nil {
+		t.Fatal("bundleCmd is nil")
+	}
+
+	if bundleCmd.Use != "bundle" {
+		t.Errorf("Expected command name 'bundle', got '%s'", bundleCmd.Use)
+	}
+
+	if bundleCmd.Short == "" {
+		t.Error("Command short description is empty")
+	}
+
+	if bundleCmd.Long == "" {
+		t.Error("Command long description is empty")
+	}
+
+	if bundleCmd.RunE == nil {
+		t.Error("Command RunE function is nil")
+	}
+}
+
+func TestBundleCommandRegistered(t *testing.T) {
+	// Test that bundle command is registered
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == "bundle" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("bundle command should be registered with root command")
+	}
+}
+
+func TestBundleCommandFlags(t *testing.T) {
+	// Test --all flag
+	allFlag := bundleCmd.Flags().Lookup("all")
+	if allFlag == nil {
+		t.Error("--all flag should be defined")
+	} else if allFlag.Value.Type() != "bool" {
+		t.Errorf("--all should be a boolean flag, got %s", allFlag.Value.Type())
+	}
+
+	// Test --dry-run flag
+	dryRunFlag := bundleCmd.Flags().Lookup("dry-run")
+	if dryRunFlag == nil {
+		t.Error("--dry-run flag should be defined")
+	} else if dryRunFlag.Value.Type() != "bool" {
+		t.Errorf("--dry-run should be a boolean flag, got %s", dryRunFlag.Value.Type())
+	}
+
+	// Test --output flag
+	outputFlag := bundleCmd.Flags().Lookup("output")
+	if outputFlag == nil {
+		t.Error("--output flag should be defined")
+	} else if outputFlag.Value.Type() != "string" {
+		t.Errorf("--output should be a string flag, got %s", outputFlag.Value.Type())
+	}
+}
+
+func TestGenerateBundleFilename(t *testing.T) {
+	tests := []struct {
+		name         string
+		customOutput string
+		expected     string
+	}{
+		{
+			name:         "default filename",
+			customOutput: "",
+			expected:     "all.md",
+		},
+		{
+			name:         "custom filename with extension",
+			customOutput: "my-bundle.md",
+			expected:     "my-bundle.md",
+		},
+		{
+			name:         "custom filename without extension",
+			customOutput: "my-bundle",
+			expected:     "my-bundle.md",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := generateBundleFilename(tt.customOutput)
+			if result != tt.expected {
+				t.Errorf("generateBundleFilename(%q) = %q, want %q", tt.customOutput, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestOptimizeContent(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no change needed",
+			input:    "line1\nline2\nline3",
+			expected: "line1\nline2\nline3",
+		},
+		{
+			name:     "remove excessive blank lines",
+			input:    "line1\n\n\n\nline2\n\n\n\nline3",
+			expected: "line1\n\nline2\n\nline3",
+		},
+		{
+			name:     "preserve single blank lines",
+			input:    "line1\n\nline2\n\nline3",
+			expected: "line1\n\nline2\n\nline3",
+		},
+		{
+			name:     "handle trailing blank lines",
+			input:    "line1\nline2\n\n\n\n",
+			expected: "line1\nline2\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := optimizeContent(tt.input)
+			if result != tt.expected {
+				t.Errorf("optimizeContent() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetAgentTasks(t *testing.T) {
+	content := &BundleContent{
+		Agents: []AgentBundleInfo{
+			{
+				FilePath: ".krci-ai/agents/test.yaml",
+				Content: `agent:
+  identity:
+    name: "Test Agent"
+  tasks:
+    - ./.krci-ai/tasks/task1.md
+    - ./.krci-ai/tasks/task2.md
+  commands:
+    help: "Show help"`,
+			},
+		},
+	}
+
+	tasks := getAgentTasks(".krci-ai/agents/test.yaml", content)
+	expected := []string{"tasks/task1.md", "tasks/task2.md"}
+
+	if len(tasks) != len(expected) {
+		t.Errorf("getAgentTasks() returned %d tasks, want %d", len(tasks), len(expected))
+		return
+	}
+
+	for i, task := range tasks {
+		if task != expected[i] {
+			t.Errorf("getAgentTasks()[%d] = %q, want %q", i, task, expected[i])
+		}
+	}
+}
+
+func TestGetAgentTasksNoTasks(t *testing.T) {
+	content := &BundleContent{
+		Agents: []AgentBundleInfo{
+			{
+				FilePath: ".krci-ai/agents/test.yaml",
+				Content: `agent:
+  identity:
+    name: "Test Agent"
+  commands:
+    help: "Show help"`,
+			},
+		},
+	}
+
+	tasks := getAgentTasks(".krci-ai/agents/test.yaml", content)
+	if len(tasks) != 0 {
+		t.Errorf("getAgentTasks() with no tasks should return empty slice, got %v", tasks)
+	}
+}
+
+func TestGenerateBundleMarkdown(t *testing.T) {
+	content := &BundleContent{
+		Agents: []AgentBundleInfo{
+			{
+				FilePath: ".krci-ai/agents/test.yaml",
+				Name:     "Test Agent",
+				Role:     "Tester",
+				Content:  "agent: test content",
+			},
+		},
+		Tasks: map[string]string{
+			"tasks/test-task.md": "# Test Task\nTest task content",
+		},
+		Templates: map[string]string{
+			"templates/test-template.md": "# Test Template\nTest template content",
+		},
+		DataFiles: map[string]string{
+			"data/test-data.md": "# Test Data\nTest data content",
+		},
+	}
+
+	result := generateBundleMarkdown(content)
+
+	// Test bundle structure
+	expectedStrings := []string{
+		"# KubeRocketAI Framework Bundle",
+		"==== FILE: .krci-ai/agents/test.yaml ====",
+		"==== END FILE ====",
+		"==== FILE: templates/test-template.md ====",
+		"==== END FILE ====",
+		"==== FILE: data/test-data.md ====",
+		"==== END FILE ====",
+		"agent: test content",
+		"Test template content",
+		"Test data content",
+	}
+
+	for _, expected := range expectedStrings {
+		if !strings.Contains(result, expected) {
+			t.Errorf("generateBundleMarkdown() should contain %q", expected)
+		}
+	}
+}
+
+func TestBundleCommandRequiresAllFlag(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "bundle-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Change to temp directory
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current dir: %v", err)
+	}
+	defer func() {
+		if chErr := os.Chdir(originalDir); chErr != nil {
+			t.Logf("Warning: failed to change back to original directory: %v", chErr)
+		}
+	}()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("Failed to change to temp dir: %v", err)
+	}
+
+	// Reset flags
+	bundleAll = false
+	bundleDryRun = false
+	bundleOutput = ""
+
+	err = runBundle(bundleCmd, []string{})
+	if err == nil {
+		t.Error("runBundle() should return error when --all flag is missing")
+	} else if !strings.Contains(err.Error(), "--all flag is required") {
+		t.Errorf("runBundle() error should mention --all flag requirement, got: %v", err)
+	}
+}
+
+func TestBundleCommandMissingFramework(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "bundle-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Change to temp directory
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current dir: %v", err)
+	}
+	defer func() {
+		if chErr := os.Chdir(originalDir); chErr != nil {
+			t.Logf("Warning: failed to change back to original directory: %v", chErr)
+		}
+	}()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("Failed to change to temp dir: %v", err)
+	}
+
+	// Set flags
+	bundleAll = true
+	bundleDryRun = false
+	bundleOutput = ""
+
+	err = runBundle(bundleCmd, []string{})
+	if err == nil {
+		t.Error("runBundle() should return error when framework not installed")
+	} else if !strings.Contains(err.Error(), "framework not installed") {
+		t.Errorf("runBundle() error should mention framework not installed, got: %v", err)
+	}
+}
+
+func TestCollectAdditionalFiles(t *testing.T) {
+	// Create a temporary directory structure
+	tempDir, err := os.MkdirTemp("", "bundle-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create test structure
+	templatesDir := filepath.Join(tempDir, ".krci-ai", "templates")
+	dataDir := filepath.Join(tempDir, ".krci-ai", "data")
+	if err := os.MkdirAll(templatesDir, 0755); err != nil {
+		t.Fatalf("Failed to create templates dir: %v", err)
+	}
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		t.Fatalf("Failed to create data dir: %v", err)
+	}
+
+	// Create test files
+	templateFile := filepath.Join(templatesDir, "test-template.md")
+	dataFile := filepath.Join(dataDir, "test-data.md")
+	if err := os.WriteFile(templateFile, []byte("template content"), 0644); err != nil {
+		t.Fatalf("Failed to create template file: %v", err)
+	}
+	if err := os.WriteFile(dataFile, []byte("data content"), 0644); err != nil {
+		t.Fatalf("Failed to create data file: %v", err)
+	}
+
+	// Test collectAdditionalFiles
+	content := &BundleContent{
+		Templates: make(map[string]string),
+		DataFiles: make(map[string]string),
+	}
+
+	err = collectAdditionalFiles(tempDir, content)
+	if err != nil {
+		t.Fatalf("collectAdditionalFiles() failed: %v", err)
+	}
+
+	// Verify files were collected
+	templatePath := "templates/test-template.md"
+	dataPath := "data/test-data.md"
+
+	if _, exists := content.Templates[templatePath]; !exists {
+		t.Errorf("Templates should contain %q", templatePath)
+	} else if content.Templates[templatePath] != "template content" {
+		t.Errorf("Template content = %q, want %q", content.Templates[templatePath], "template content")
+	}
+
+	if _, exists := content.DataFiles[dataPath]; !exists {
+		t.Errorf("DataFiles should contain %q", dataPath)
+	} else if content.DataFiles[dataPath] != "data content" {
+		t.Errorf("Data content = %q, want %q", content.DataFiles[dataPath], "data content")
+	}
+}
+
+func TestWriteBundleFile(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "bundle-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	bundlePath := filepath.Join(tempDir, "test-bundle.md")
+	testContent := "# Test Bundle\nTest content"
+
+	err = writeBundleFile(bundlePath, testContent)
+	if err != nil {
+		t.Fatalf("writeBundleFile() failed: %v", err)
+	}
+
+	// Verify file was created with correct content
+	content, err := os.ReadFile(bundlePath)
+	if err != nil {
+		t.Fatalf("Failed to read bundle file: %v", err)
+	}
+	if string(content) != testContent {
+		t.Errorf("Bundle file content = %q, want %q", string(content), testContent)
+	}
+}
+
+func TestWriteBundleFileInvalidPath(t *testing.T) {
+	// Test writing to invalid path
+	invalidPath := "/invalid/path/bundle.md"
+	testContent := "test content"
+
+	err := writeBundleFile(invalidPath, testContent)
+	if err == nil {
+		t.Error("writeBundleFile() should fail with invalid path")
+	} else if !strings.Contains(err.Error(), "failed to create bundle file") {
+		t.Errorf("writeBundleFile() error should mention file creation failure, got: %v", err)
+	}
+}
+
+func TestBundleHeaderGeneration(t *testing.T) {
+	var result strings.Builder
+	addBundleHeader(&result)
+
+	content := result.String()
+	expectedStrings := []string{
+		"# KubeRocketAI Framework Bundle",
+		"**Generated:**",
+		"## Usage Instructions",
+		"### File Format Guide",
+		"### For LLM Understanding",
+		"==== FILE: <path> ====",
+		"==== END FILE ====",
+	}
+
+	for _, expected := range expectedStrings {
+		if !strings.Contains(content, expected) {
+			t.Errorf("Bundle header should contain %q", expected)
+		}
+	}
+}
+
+func TestAddAgentSection(t *testing.T) {
+	var result strings.Builder
+	agent := AgentBundleInfo{
+		FilePath: ".krci-ai/agents/test.yaml",
+		Name:     "Test Agent",
+		Role:     "Tester",
+		Content:  "agent content",
+	}
+	content := &BundleContent{
+		Tasks: map[string]string{
+			"tasks/test-task.md": "task content",
+		},
+	}
+
+	addAgentSection(&result, agent, content)
+
+	output := result.String()
+	expectedStrings := []string{
+		"==== FILE: .krci-ai/agents/test.yaml ====",
+		"agent content",
+		"==== END FILE ====",
+	}
+
+	for _, expected := range expectedStrings {
+		if !strings.Contains(output, expected) {
+			t.Errorf("Agent section should contain %q", expected)
+		}
+	}
+}
+
+func TestAddSharedTemplates(t *testing.T) {
+	var result strings.Builder
+	content := &BundleContent{
+		Templates: map[string]string{
+			"templates/test.md": "template content",
+		},
+	}
+
+	addSharedTemplates(&result, content)
+
+	output := result.String()
+	expectedStrings := []string{
+		"# Shared Templates",
+		"==== FILE: templates/test.md ====",
+		"template content",
+		"==== END FILE ====",
+	}
+
+	for _, expected := range expectedStrings {
+		if !strings.Contains(output, expected) {
+			t.Errorf("Shared templates should contain %q", expected)
+		}
+	}
+}
+
+func TestAddSharedTemplatesEmpty(t *testing.T) {
+	var result strings.Builder
+	content := &BundleContent{
+		Templates: make(map[string]string),
+	}
+
+	addSharedTemplates(&result, content)
+
+	output := result.String()
+	if output != "" {
+		t.Errorf("Empty templates should produce no output, got %q", output)
+	}
+}
+
+func TestAddSharedDataFiles(t *testing.T) {
+	var result strings.Builder
+	content := &BundleContent{
+		DataFiles: map[string]string{
+			"data/test.md": "data content",
+		},
+	}
+
+	addSharedDataFiles(&result, content)
+
+	output := result.String()
+	expectedStrings := []string{
+		"# Reference Data",
+		"==== FILE: data/test.md ====",
+		"data content",
+		"==== END FILE ====",
+	}
+
+	for _, expected := range expectedStrings {
+		if !strings.Contains(output, expected) {
+			t.Errorf("Shared data files should contain %q", expected)
+		}
+	}
+}
+
+func TestAddSharedDataFilesEmpty(t *testing.T) {
+	var result strings.Builder
+	content := &BundleContent{
+		DataFiles: make(map[string]string),
+	}
+
+	addSharedDataFiles(&result, content)
+
+	output := result.String()
+	if output != "" {
+		t.Errorf("Empty data files should produce no output, got %q", output)
+	}
+}


### PR DESCRIPTION
Add comprehensive bundle generation capability that packages entire KubeRocketAI framework context into single files for web chat tools (ChatGPT, Claude Web, Gemini Pro).

Features:
- New 'krci-ai bundle --all' command with comprehensive CLI support
- Framework validation integration before bundle generation
- Agent discovery and dependency resolution for all 6 SDLC roles
- Optimized markdown format with collision-resistant delimiters
- Custom output paths via --output flag and dry-run functionality
- Bundle directory creation at ./.krci-ai/bundle/ with proper permissions
- Content optimization and error handling for enterprise workflows

Closes #44