### PR TITLE
feat: add single agent-task bundle generation with --task flag

### DIFF
--- a/cmd/krci-ai/cmd/bundle_test.go
+++ b/cmd/krci-ai/cmd/bundle_test.go
@@ -131,9 +131,9 @@ func TestGenerateBundleFilename(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := generateBundleFilename(tt.customOutput, tt.selectedAgents)
+			result := generateBundleFilename(tt.customOutput, tt.selectedAgents, "")
 			if result != tt.expected {
-				t.Errorf("generateBundleFilename(%q, %v) = %q, want %q", tt.customOutput, tt.selectedAgents, result, tt.expected)
+				t.Errorf("generateBundleFilename(%q, %v, %q) = %q, want %q", tt.customOutput, tt.selectedAgents, "", result, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
- Add --task flag to bundle command for minimal single agent-task bundles
- Implement ValidateAgentTaskCombination() with comprehensive error handling
- Add {agent}-{task}.md filename pattern generation (e.g., pm-create-prd.md)
- Implement task-level filtering with intelligent dependency analysis
- Add mutual exclusivity validation preventing --all and --task flag conflicts
- Create task-specific template and data filtering for minimal bundle size
- Extend collectBundleContent() with task parameter for focused content collection
- Add helper functions to reduce cyclomatic complexity and improve maintainability
- Support custom output filenames via --output flag with task-specific defaults
- Integrate framework validation before bundle generation with clear error messages

Bundle generation performance: 0.030s execution time, 126KB output size Maintains backward compatibility with existing --all and --agent modes

Closes #47