### PR TITLE
refactor(pm): remove epic/story creation from PM tasks

### DIFF
--- a/.krci-ai/tasks/create-prd.md
+++ b/.krci-ai/tasks/create-prd.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Create a streamlined PRD that drives team alignment on what to build and why, following the proven 6-8 page structure focused on user needs and business value rather than technical specifications. This PRD enables Epic and Story creation while maintaining clear traceability from Project Brief through implementation.
+Create a streamlined PRD that drives team alignment on what to build and why, following the proven 6-8 page structure focused on user needs and business value rather than technical specifications. This PRD includes epic-level feature definitions while maintaining clear traceability from Project Brief.
 
 ## Prerequisites
 
@@ -26,22 +26,22 @@ Validation: Verify all dependencies exist at specified paths before proceeding. 
 1. **Follow SDLC workflow**: Reference [sdlc-framework.md](./.krci-ai/data/common/sdlc-framework.md) for PRD dependencies and quality gates
 2. **Use business frameworks**: Apply methodologies from [business-frameworks.md](./.krci-ai/data/business-frameworks.md)
 3. **Format output**: Use [prd-template.md](./.krci-ai/templates/prd-template.md) for structure
-4. **Ensure traceability**: Link back to Project Brief and enable Epic creation
+4. **Ensure traceability**: Link back to Project Brief and include epic-level feature definitions
 
 ## Output Format
 
 - **Location**: `/docs/prd/prd.md` (EXACT path and filename)
 - **Length**: 6-8 pages maximum for team consumption
-- **Requirements Format**: Use BR1, BR2, BR3... for business requirements and NFR1, NFR2, NFR3... for system requirements with P0/P1/P2 priority indicators
-- **Downstream Enable**: Enables Epic creation at `/docs/epics/` and Architecture at `/docs/architecture/`
+- **Requirements Format**: Use BR1, BR2, BR3... for business requirements and NFR1, NFR2, NFR3... for system requirements with P0/P1/P2 priority indicators and epic-level feature definitions
+- **Downstream Enable**: Provides clear requirements structure for development teams
 
 ## Success Criteria
 
 - [ ] **File saved** to `/docs/prd/prd.md`
 - [ ] **Length** is 6-8 pages maximum
-- [ ] **Requirements numbered** (BR1, BR2, NFR1, NFR2) with priority indicators for Epic mapping
+- [ ] **Requirements numbered** (BR1, BR2, NFR1, NFR2) with priority indicators and epic-level features
 - [ ] **Project Brief link** clear connection to problem/opportunity
-- [ ] **Epic enablement** requirements structured for breakdown into Epic features
+- [ ] **Feature structure** requirements organized into logical epic-level themes
 - [ ] **User focus** prioritizes user needs over technical implementation details
 - [ ] **Stakeholder alignment** all key requirements captured and validated
 
@@ -59,7 +59,7 @@ Validation: Verify all dependencies exist at specified paths before proceeding. 
 - [ ] **Business requirements**: Define BR1, BR2, BR3... (what business functionality is needed)
 - [ ] **Non-functional requirements**: Define NFR1, NFR2, NFR3... (how system should behave/perform)
 - [ ] **Priority assignment**: Add P0/P1/P2 priority indicators to each requirement
-- [ ] **Epic groupings**: Structure requirements into logical Epic themes
+- [ ] **Epic groupings**: Structure requirements into logical epic-level feature themes within the PRD
 
 ### Design Phase
 
@@ -81,16 +81,16 @@ Validation: Verify all dependencies exist at specified paths before proceeding. 
 
 - **User-Centered**: Always prioritize user needs over technical implementation details
 - **Evidence-Based**: Support all requirements with user research and business data
-- **Traceable**: Maintain clear connection from Project Brief → PRD → Epic creation
+- **Traceable**: Maintain clear connection from Project Brief → PRD with epic-level features
 - **Measurable**: Ensure all success metrics are specific, testable, and time-bound
 
 ### LLM Error Prevention Checklist
 
 - **Avoid**: Technical implementation details (save for Architecture documents)
 - **Avoid**: Solution-oriented problem statements (focus on user pain points)
-- **Avoid**: Vague requirements that cannot map to Epic features
+- **Avoid**: Vague requirements that cannot be grouped into epic-level features
 - **Reference**: Use [prd-template.md](./.krci-ai/templates/prd-template.md) for all formatting guidance and examples
 
 ### SDLC Integration Context
 
-This PRD enables immediate Epic creation by providing numbered requirements (BR1, BR2, NFR1...) with priorities that Epics can reference, requirement groupings that map to Epic themes, and success metrics that become Epic acceptance criteria.
+This PRD provides numbered requirements (BR1, BR2, NFR1...) with priorities organized into epic-level feature themes, requirement groupings that structure development work, and success metrics that guide implementation decisions.

--- a/.krci-ai/tasks/update-prd.md
+++ b/.krci-ai/tasks/update-prd.md
@@ -2,14 +2,14 @@
 
 ## Description
 
-Update an existing PRD with new requirements, scope changes, or refined business needs while maintaining traceability to Project Brief and enabling Epic/Story creation. Focus on change impact assessment and downstream communication to ensure existing Epics and Stories remain aligned with updated requirements.
+Update an existing PRD with new requirements, scope changes, or refined business needs while maintaining traceability to Project Brief. Focus on change impact assessment and clear documentation to ensure requirements remain aligned with strategic objectives while defining epic-level features within the PRD.
 
 ## Prerequisites
 
 - [ ] **Existing PRD**: `/docs/prd/prd.md` exists and is properly accessible
 - [ ] **Change trigger**: Clear reason for update (Project Brief changes, user research, business priorities, technical constraints, stakeholder feedback)
 - [ ] **Stakeholder input**: Understanding of what specifically needs to change and why
-- [ ] **Epic/Story review**: Current status of downstream artifacts
+- [ ] **Epic/Story review**: Current understanding of feature groupings and requirements structure
 
 ### Reference Assets
 
@@ -38,22 +38,22 @@ Before making ANY changes to the PRD, you MUST:
 1. **Follow SDLC workflow**: Reference [sdlc-framework.md](./.krci-ai/data/common/sdlc-framework.md) for change management process
 2. **Use business frameworks**: Apply methodologies from [business-frameworks.md](./.krci-ai/data/business-frameworks.md)
 3. **Format output**: Maintain [prd-template.md](./.krci-ai/templates/prd-template.md) structure
-4. **Maintain traceability**: Update BR/NFR numbering and assess Epic/Story impact
+4. **Maintain traceability**: Update BR/NFR numbering and include epic-level feature definitions
 
 ## Output Format
 
 - **Location**: Updates existing `/docs/prd/prd.md` (EXACT path and filename)
 - **Length**: Maintain 6-8 pages maximum
-- **Requirements Format**: Maintain BR1, BR2, BR3... and NFR1, NFR2, NFR3... numbering with P0/P1/P2 priority indicators
-- **Impact Documentation**: Clear notes on what changed and Epic/Story impact
-- **Downstream Updates**: List of Epic/Story artifacts requiring updates
+- **Requirements Format**: Maintain BR1, BR2, BR3... and NFR1, NFR2, NFR3... numbering with P0/P1/P2 priority indicators and epic-level feature definitions
+- **Impact Documentation**: Clear notes on what changed and feature impact
+- **Downstream Updates**: List of feature areas requiring updates
 
 ## Success Criteria
 
 - [ ] **File updated** at `/docs/prd/prd.md` reflects all changes
-- [ ] **Requirements numbered** BR/NFR structure maintained with priority indicators for Epic mapping
+- [ ] **Requirements numbered** BR/NFR structure maintained with priority indicators and epic-level features
 - [ ] **Change documented** clear record of what changed and why
-- [ ] **Downstream impact** identified which Epic/Story artifacts need updates
+- [ ] **Feature impact** identified which feature areas need updates
 - [ ] **Quality maintained** document remains 6-8 pages maximum
 - [ ] **Project Brief alignment** changes align with Project Brief updates (if any)
 - [ ] **Stakeholder approval** key stakeholders have approved requirement changes
@@ -65,14 +65,14 @@ Before making ANY changes to the PRD, you MUST:
 - [ ] **User interview**: Ask user what specific changes they want to make to the PRD
 - [ ] **Change justification**: Understand why these changes are needed (stakeholder feedback, new requirements, market changes, etc.)
 - [ ] **Scope definition**: Clarify which PRD sections need updating and what specific content changes are required
-- [ ] **Impact discussion**: Explain potential impact on existing Epics and Stories to user
+- [ ] **Impact discussion**: Explain potential impact on existing features to user
 - [ ] **User approval**: Get explicit user confirmation before proceeding with any changes
 - [ ] **Change plan agreement**: Confirm the proposed approach with user before implementation
 
 ### Assessment Phase (ONLY AFTER USER APPROVAL)
 
 - [ ] **Change scope**: Identify which sections need updating based on user requirements
-- [ ] **Impact analysis**: Evaluate how changes affect existing Epics (`/docs/epics/`) and Stories (`/docs/stories/`)
+- [ ] **Impact analysis**: Evaluate how changes affect existing feature definitions and requirements structure
 - [ ] **Stakeholder review**: Confirm who needs to approve these changes before implementation
 - [ ] **Requirements mapping**: Understand which BR/NFR numbers and priorities are affected
 
@@ -81,7 +81,7 @@ Before making ANY changes to the PRD, you MUST:
 - [ ] **Business requirements**: Update BR1, BR2, BR3... with new business functionality needs
 - [ ] **Non-functional requirements**: Update NFR1, NFR2, NFR3... with new system behavior/performance needs
 - [ ] **Priority assessment**: Review and update P0/P1/P2 priority indicators as needed
-- [ ] **Epic mapping**: Ensure updated requirements can still map to logical Epic groupings
+- [ ] **Epic groupings**: Ensure updated requirements can be organized into logical epic-level features within the PRD
 
 ### Update Phase
 
@@ -92,17 +92,16 @@ Before making ANY changes to the PRD, you MUST:
 
 ### Change Management Phase
 
-- [ ] **Epic impact assessment**: Determine which Epics (`{epic_number}-epic-{slug}.md`) need updating
-- [ ] **Story impact review**: Assess if in-progress Stories (`{epic_number}.{story_number}.story.md`) are affected
-- [ ] **Team communication**: Notify Epic owners and development teams of changes
-- [ ] **Documentation**: Record change rationale and downstream impact plan
+- [ ] **Feature impact assessment**: Determine which feature areas need updating based on requirement changes
+- [ ] **Team communication**: Notify development teams of requirement changes
+- [ ] **Documentation**: Record change rationale and feature impact plan
 
 ## Content Guidelines
 
 ### Quality Principles for LLM Self-Evaluation
 
-- **Change Impact Focused**: Always assess Epic/Story impact before implementing PRD changes
-- **Requirement Versioning**: Maintain BR/NFR numbering and priority consistency for Epic traceability
+- **Change Impact Focused**: Always assess feature impact before implementing PRD changes
+- **Requirement Versioning**: Maintain BR/NFR numbering and priority consistency with epic-level feature definitions
 - **Stakeholder Aligned**: Ensure all requirement changes have proper approval before implementation
 - **Quality Preserved**: Keep updates within 6-8 page limit while maintaining user-centered focus
 
@@ -110,12 +109,12 @@ Before making ANY changes to the PRD, you MUST:
 
 - **NEVER**: Start making PRD changes without explicit user consultation and approval
 - **NEVER**: Assume what changes the user wants - always ask for specific requirements
-- **Avoid**: Breaking existing BR/NFR numbering that Epics depend on
-- **Avoid**: Making changes without assessing downstream Epic/Story impact
+- **Avoid**: Breaking existing BR/NFR numbering that features depend on
+- **Avoid**: Making changes without assessing feature impact
 - **Avoid**: Updating requirements without proper stakeholder approval process
 - **Always**: Wait for user confirmation before proceeding with any edits
 - **Reference**: Use [prd-template.md](./.krci-ai/templates/prd-template.md) for all formatting consistency
 
 ### SDLC Integration Context
 
-This update enables continued Epic/Story development by maintaining requirement traceability, preserving BR/NFR numbering for Epic mapping, assessing which in-progress Stories need updates, and communicating changes to development teams with clear impact assessment and timeline considerations.
+This update enables continued development by maintaining requirement traceability, preserving BR/NFR numbering with epic-level features, and communicating changes to development teams with clear impact assessment and timeline considerations.

--- a/.krci-ai/tasks/update-project-brief.md
+++ b/.krci-ai/tasks/update-project-brief.md
@@ -38,20 +38,20 @@ Before making ANY changes to the Project Brief, you MUST:
 1. **Follow SDLC workflow**: Reference [sdlc-framework.md](./.krci-ai/data/common/sdlc-framework.md) for change impact assessment
 2. **Use business frameworks**: Apply methodologies from [business-frameworks.md](./.krci-ai/data/business-frameworks.md)
 3. **Format output**: Maintain [project-brief-template.md](./.krci-ai/templates/project-brief-template.md) structure
-4. **Assess downstream impact**: Identify which PRD and Epic artifacts need updates
+4. **Assess downstream impact**: Identify which PRD artifacts need updates
 
 ## Output Format
 
 - **Location**: Updates existing `/docs/prd/project-brief.md` (EXACT path and filename)
 - **Length**: Maintain 2-3 pages maximum
 - **Impact Documentation**: Clear notes on what changed and downstream impact
-- **Downstream Updates**: List of PRD/Epic artifacts requiring updates
+- **Downstream Updates**: List of PRD artifacts requiring updates
 
 ## Success Criteria
 
 - [ ] **File updated** at `/docs/prd/project-brief.md` reflects all changes
 - [ ] **Change documented** with clear record of what changed and why
-- [ ] **Downstream impact** identified which PRD/Epic artifacts need updates
+- [ ] **Downstream impact** identified which PRD artifacts need updates
 - [ ] **Quality maintained** document remains 2-3 pages maximum
 - [ ] **Strategic alignment** changes support overall product strategy
 - [ ] **Stakeholder communication** key stakeholders informed of strategic changes
@@ -63,7 +63,7 @@ Before making ANY changes to the Project Brief, you MUST:
 - [ ] **User interview**: Ask user what specific changes they want to make to the Project Brief
 - [ ] **Change justification**: Understand why these changes are needed (strategic shifts, market changes, stakeholder feedback, resource changes, etc.)
 - [ ] **Scope definition**: Clarify which Project Brief sections need updating and what specific content changes are required
-- [ ] **Impact discussion**: Explain potential impact on existing PRD and downstream artifacts to user
+- [ ] **Impact discussion**: Explain potential impact on existing PRD artifacts to user
 - [ ] **User approval**: Get explicit user confirmation before proceeding with any changes
 - [ ] **Change plan agreement**: Confirm the proposed approach with user before implementation
 
@@ -71,7 +71,7 @@ Before making ANY changes to the Project Brief, you MUST:
 
 - [ ] **Change scope**: Identify which sections need updating based on user requirements (Executive Summary, Problem, Opportunity, Users, Success Metrics, Constraints, Risks)
 - [ ] **Business impact**: Analyze how changes affect product strategy and business case
-- [ ] **Downstream impact**: Evaluate how changes affect existing PRD (`/docs/prd/prd.md`) and subsequent artifacts
+- [ ] **Downstream impact**: Evaluate how changes affect existing PRD (`/docs/prd/prd.md`) artifacts
 - [ ] **Stakeholder validation**: Confirm changes with key stakeholders
 
 ### Update Phase
@@ -84,7 +84,6 @@ Before making ANY changes to the Project Brief, you MUST:
 ### Change Management Phase
 
 - [ ] **PRD impact analysis**: Determine if PRD needs updating based on Project Brief changes
-- [ ] **Epic impact review**: Assess if strategic changes affect Epic prioritization or scope
 - [ ] **Stakeholder communication**: Notify key stakeholders of strategic changes and implications
 - [ ] **Documentation**: Record change rationale and downstream impact plan
 
@@ -94,7 +93,7 @@ Before making ANY changes to the Project Brief, you MUST:
 
 - **Strategic Focus**: Focus on strategic foundation changes rather than tactical adjustments
 - **Foundation Strength**: Ensure changes strengthen rather than weaken the overall strategic foundation
-- **Cascade Management**: Assess how strategic changes flow through entire SDLC chain to downstream artifacts
+- **Cascade Management**: Assess how strategic changes flow through PRD requirements
 - **Long-term Alignment**: Consider long-term strategic implications beyond immediate tactical changes
 
 ### LLM Error Prevention Checklist
@@ -102,11 +101,11 @@ Before making ANY changes to the Project Brief, you MUST:
 - **NEVER**: Start making Project Brief changes without explicit user consultation and approval
 - **NEVER**: Assume what changes the user wants - always ask for specific requirements
 - **Avoid**: Making changes without clear strategic justification and stakeholder approval
-- **Avoid**: Updating without assessing downstream PRD and Epic artifact impact
+- **Avoid**: Updating without assessing downstream PRD impact
 - **Avoid**: Expanding scope beyond strategic foundation changes into tactical details
 - **Always**: Wait for user confirmation before proceeding with any edits
 - **Reference**: Use [project-brief-template.md](./.krci-ai/templates/project-brief-template.md) for all formatting consistency
 
 ### SDLC Integration Context
 
-This update enables continued strategic alignment by managing strategic changes flowing through the entire SDLC chain, assessing PRD and Epic alignment impacts, ensuring stakeholder approval of strategic changes, and maintaining clear documentation of strategic change rationale and downstream artifact impact.
+This update enables continued strategic alignment by managing strategic changes flowing through PRD requirements, ensuring stakeholder approval of strategic changes, and maintaining clear documentation of strategic change rationale and downstream PRD impact.


### PR DESCRIPTION
- Remove references to creating separate Epic/Story artifacts from PM tasks
- Focus PM role on epic-level features within PRD only
- Clarify PM creates strategic requirements, PO handles detailed stories
- Update update-project-brief.md and update-prd.md tasks
- Maintain requirement structure (BR/NFR) for organization
- Prevent PM role scope creep into PO responsibilities