### PR TITLE
feat!: start using sub-directories for Claude Code and Cursor

### DIFF
--- a/internal/assets/installer.go
+++ b/internal/assets/installer.go
@@ -34,8 +34,8 @@ const (
 	DataDir           = "data"
 	configDir         = "config"
 	embeddedPrefix    = "assets/framework/core"
-	cursorRulesDir    = ".cursor/rules"
-	claudeCommandsDir = ".claude/commands"
+	cursorRulesDir    = ".cursor/rules/krci-ai"
+	claudeCommandsDir = ".claude/commands/krci-ai"
 	vscodeModesDir    = ".github/chatmodes"
 	windsurfRulesDir  = ".windsurf/rules"
 	// File extensions


### PR DESCRIPTION
Ensure teams can hosts their own rules without mixing the framework ones

BREAKING CHANGE: We've start using 'subfolder' for the framework

Closes: #79