### PR TITLE
refactor(install): eliminate global variables in flag handling to imp…

### DIFF
--- a/.github/chatmodes/pm.chatmode.md
+++ b/.github/chatmodes/pm.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: Activate Senior Product Manager role for specialized development assistance
-tools: ['changes', 'codebase', 'editFiles', 'fetch', 'findTestFiles', 'githubRepo', 'problems', 'runCommands', 'search', 'searchResults', 'terminalLastCommand', 'usages']
+tools: ['codebase', 'usages', 'problems', 'changes', 'terminalLastCommand', 'fetch', 'findTestFiles', 'searchResults', 'githubRepo', 'editFiles', 'search', 'runCommands', 'sequential-thinking']
 ---
 
 # Senior Product Manager Agent Chat Mode

--- a/cmd/krci-ai/cmd/validate.go
+++ b/cmd/krci-ai/cmd/validate.go
@@ -52,22 +52,29 @@ Examples:
 	RunE: runValidate,
 }
 
-// Validation flags
-var (
-	verboseOutput bool
-	quietOutput   bool
-)
+// Validation flags removed - now using GetBool pattern
 
 func init() {
 	rootCmd.AddCommand(validateCmd)
 
 	// Add flags
-	validateCmd.Flags().BoolVarP(&verboseOutput, "verbose", "v", false, "verbose output with detailed validation results")
-	validateCmd.Flags().BoolVarP(&quietOutput, "quiet", "q", false, "quiet output, only show summary")
+	validateCmd.Flags().BoolP("verbose", "v", false, "verbose output with detailed validation results")
+	validateCmd.Flags().BoolP("quiet", "q", false, "quiet output, only show summary")
 }
 
 // runValidate executes the validation command
 func runValidate(cmd *cobra.Command, args []string) error {
+	// Get flags
+	verboseOutput, err := cmd.Flags().GetBool("verbose")
+	if err != nil {
+		return fmt.Errorf("failed to get verbose flag: %w", err)
+	}
+
+	quietOutput, err := cmd.Flags().GetBool("quiet")
+	if err != nil {
+		return fmt.Errorf("failed to get quiet flag: %w", err)
+	}
+
 	// Get current working directory
 	currentDir, err := os.Getwd()
 	if err != nil {

--- a/cmd/krci-ai/cmd/validate_test.go
+++ b/cmd/krci-ai/cmd/validate_test.go
@@ -100,6 +100,8 @@ Test task description.
 
 		// Create test command
 		cmd := &cobra.Command{}
+		cmd.Flags().BoolP("verbose", "v", false, "verbose output")
+		cmd.Flags().BoolP("quiet", "q", false, "quiet output")
 
 		// Test runValidate function - this will call os.Exit, so we expect it to panic in test
 		// We'll test that the function can be called without initial errors
@@ -142,6 +144,8 @@ Test task description.
 
 		// Create test command
 		cmd := &cobra.Command{}
+		cmd.Flags().BoolP("verbose", "v", false, "verbose output")
+		cmd.Flags().BoolP("quiet", "q", false, "quiet output")
 
 		// Test that runValidate can be called
 		// Since it calls os.Exit, we use a defer/recover pattern
@@ -163,23 +167,28 @@ Test task description.
 	t.Run("runValidate with flags", func(t *testing.T) {
 		// Test that flags can be set without error
 		cmd := &cobra.Command{}
-		cmd.Flags().BoolVarP(&verboseOutput, "verbose", "v", false, "verbose output")
-		cmd.Flags().BoolVarP(&quietOutput, "quiet", "q", false, "quiet output")
+		cmd.Flags().BoolP("verbose", "v", false, "verbose output")
+		cmd.Flags().BoolP("quiet", "q", false, "quiet output")
 
 		// Set verbose flag
-		verboseOutput = true
-		defer func() { verboseOutput = false }()
-
+		cmd.Flags().Set("verbose", "true")
 		// Set quiet flag
-		quietOutput = true
-		defer func() { quietOutput = false }()
+		cmd.Flags().Set("quiet", "true")
 
 		// Verify flags can be accessed (basic flag test)
-		if !verboseOutput {
+		verboseFlag, err := cmd.Flags().GetBool("verbose")
+		if err != nil {
+			t.Errorf("Failed to get verbose flag: %v", err)
+		}
+		if !verboseFlag {
 			t.Error("Expected verbose flag to be true")
 		}
 
-		if !quietOutput {
+		quietFlag, err := cmd.Flags().GetBool("quiet")
+		if err != nil {
+			t.Errorf("Failed to get quiet flag: %v", err)
+		}
+		if !quietFlag {
 			t.Error("Expected quiet flag to be true")
 		}
 	})


### PR DESCRIPTION
…rove thread safety and testability

Global variables create package-level state pollution, race conditions in concurrent environments, and complex test scenarios requiring state cleanup. This change adopts industry-standard GetString pattern used by kubectl and docker CLI, improving code maintainability and following Cobra best practices.

Closes: #87