### PR TITLE
feat: Add task dependencies field to task frontmatter

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -102,6 +102,17 @@
             "env": {
                 "KRCI_AI_PROJECT_DIR": "${workspaceFolder}"
             }
+        },
+        {
+            "name": "bundle pm",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/cmd/krci-ai/main.go",
+            "args": ["bundle", "--agent=pm"],
+            "env": {
+                "KRCI_AI_PROJECT_DIR": "${workspaceFolder}"
+            }
         }
     ]
 }

--- a/cmd/krci-ai/assets/framework/core/tasks/doc-review.md
+++ b/cmd/krci-ai/assets/framework/core/tasks/doc-review.md
@@ -2,8 +2,6 @@
 dependencies:
   data:
     - krci-ai/core-sdlc-framework.md
-  templates:
-    - documentation-review.md
 ---
 
 # Task: Documentation Review

--- a/cmd/krci-ai/assets/framework/core/tasks/go-dev-review-code.md
+++ b/cmd/krci-ai/assets/framework/core/tasks/go-dev-review-code.md
@@ -3,8 +3,6 @@ dependencies:
   data:
     - go-coding-standards.md
     - operator-best-practices.md
-  mcp_servers:
-    - github
 ---
 
 # Task: Review Go code

--- a/cmd/krci-ai/cmd/tokens_test.go
+++ b/cmd/krci-ai/cmd/tokens_test.go
@@ -181,6 +181,7 @@ func TestOutputAgentTokensTable(t *testing.T) {
 			Tasks     []tokens.AssetTokenInfo `json:"tasks"`
 			Templates []tokens.AssetTokenInfo `json:"templates"`
 			DataFiles []tokens.AssetTokenInfo `json:"data_files"`
+			TasksRef  []tokens.AssetTokenInfo `json:"tasks_ref"`
 		}{
 			Tasks: []tokens.AssetTokenInfo{
 				{Path: "create-story.md", Tokens: 300},
@@ -190,6 +191,9 @@ func TestOutputAgentTokensTable(t *testing.T) {
 			},
 			DataFiles: []tokens.AssetTokenInfo{
 				{Path: "best-practices.md", Tokens: 500},
+			},
+			TasksRef: []tokens.AssetTokenInfo{
+				{Path: "create-story.md", Tokens: 300},
 			},
 		},
 	}
@@ -228,6 +232,7 @@ func TestOutputAgentTokensTableNoDependencies(t *testing.T) {
 			Tasks     []tokens.AssetTokenInfo `json:"tasks"`
 			Templates []tokens.AssetTokenInfo `json:"templates"`
 			DataFiles []tokens.AssetTokenInfo `json:"data_files"`
+			TasksRef  []tokens.AssetTokenInfo `json:"tasks_ref"`
 		}{}, // No dependencies
 	}
 

--- a/internal/processor/models.go
+++ b/internal/processor/models.go
@@ -23,6 +23,7 @@ type TaskDependenciesYamlRepresentation struct {
 	Dependencies struct {
 		Templates  []string `yaml:"templates"`
 		DataFiles  []string `yaml:"data"`
+		Tasks      []string `yaml:"tasks"`
 		McpServers []string `yaml:"mcp_servers"`
 	} `yaml:"dependencies"`
 }

--- a/internal/tokens/calculator.go
+++ b/internal/tokens/calculator.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/KubeRocketCI/kuberocketai/internal/assets"
 	"github.com/KubeRocketCI/kuberocketai/internal/bundle"
+	"github.com/KubeRocketCI/kuberocketai/internal/utils"
 )
 
 // DiscoveryInterface defines the interface for asset discovery operations
@@ -198,8 +199,9 @@ func (c *Calculator) calculateSingleAgentTokens(ctx context.Context, agent *asse
 	agentInfo.Assets = append(agentInfo.Assets, agentAsset)
 	agentInfo.TotalTokens += agentAsset.Tokens
 
+	taskPaths := utils.DeduplicateStrings(append(agent.GetAllTasksPaths(), agent.GetAllReferencedTasksPaths()...))
 	// Calculate tokens for task dependencies
-	agentInfo.Dependencies.Tasks, err = c.calculateAssetTokens(ctx, agent.GetAllTasksPaths(), assets.TasksDir)
+	agentInfo.Dependencies.Tasks, err = c.calculateAssetTokens(ctx, taskPaths, assets.TasksDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to calculate task tokens: %w", err)
 	}

--- a/internal/tokens/engine.go
+++ b/internal/tokens/engine.go
@@ -45,6 +45,7 @@ type AgentTokenInfo struct {
 		Tasks     []AssetTokenInfo `json:"tasks"`
 		Templates []AssetTokenInfo `json:"templates"`
 		DataFiles []AssetTokenInfo `json:"data_files"`
+		TasksRef  []AssetTokenInfo `json:"tasks_ref"`
 	} `json:"dependencies"`
 }
 


### PR DESCRIPTION
Introduced a new `tasks` field in task frontmatter dependencies
to support task-to-task relationships and dependency tracking.

Changes:
- Add `tasks` field to TaskDependenciesYamlRepresentation
- Update asset discovery to collect referenced tasks
- Extend bundle collection to include task dependencies
- Update token calculation for task references
- Modify installer to handle task dependencies

Example usage:
```
---
dependencies:
  data:
    - validation-frameworks.md
  templates:
    - project-brief-template-advanced.md
  tasks:
    - gather-project-context.md
---
```