### PR TITLE
feat: Use installed agents for bundle generation

### DIFF
--- a/cmd/krci-ai/cmd/bundle.go
+++ b/cmd/krci-ai/cmd/bundle.go
@@ -204,7 +204,7 @@ func runBundle(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create discovery service
-	discovery := assets.NewEmbeddedDiscovery(GetEmbeddedAssets(), assets.EmbeddedPrefix)
+	discovery := assets.NewDiscovery(assets.GetKrciPath(projectRoot))
 
 	// Parse and validate agent selection
 	selectedAgents, err := parseAndValidateAgents(cmd, discovery, output)


### PR DESCRIPTION
Use installed agents for bundle generation.
Related: #121 